### PR TITLE
Remove duplicate service bit line

### DIFF
--- a/app/mixins/nodes-data.js
+++ b/app/mixins/nodes-data.js
@@ -21,8 +21,8 @@ export default Mixin.create({
     if (services & 4) { serviceBits.push('NODE_BLOOM'); }
     if (services & 8) { serviceBits.push('NODE_WITNESS'); }
     if (services & 16) { serviceBits.push('NODE_XTHIN'); }
-    if (services & 16) { serviceBits.push('NODE_XTHIN'); }
-    if (services & 32) { serviceBits.push('NODE_GRAPHENE'); }
+    if (services & 32) { serviceBits.push('NODE_CASH'); }
+    if (services & 64) { serviceBits.push('NODE_GRAPHENE'); }
     return serviceBits;
   },
 


### PR DESCRIPTION
Causes NODE_XTHIN to show up twice in node summary for nodes offering this service.  Fixes bug introduced in #26 