### PR TITLE
Allow filtering for nodes by services offered

### DIFF
--- a/app/mixins/nodes-data.js
+++ b/app/mixins/nodes-data.js
@@ -85,7 +85,8 @@ export default Mixin.create({
     if (filterQuery) {
       result = allNodes.filter((node) => {
         const regexp = new RegExp(escape(filterQuery), 'i');
-        return escape(node.address).match(regexp) || escape(node.userAgent).match(regexp);
+        return escape(node.address).match(regexp) || escape(node.userAgent).match(regexp) ||
+               escape(this._serviceBits(node.services).join(' '));
       });
     }
     return result.sortBy('connectedSince').reverse().map((node, idx) => {


### PR DESCRIPTION
To me it would be very useful to be able to search for nodes by services offered (more interesting than searching by address or agent string).  This is a quick attempt at adding that functionality.

I'm not familiar with js frameworks and wasn't sure if it would be valid and/or better to use the following:
`escape(this._serviceBits(node.services).join(' '))`
or
`escape(get(node, 'userAgentData')[1])`

NOTE: I do not have a development environment set up for this so have not tested.